### PR TITLE
Fail immediately to skip expectation timeouts

### DIFF
--- a/Sources/PublisherExpectations/PublisherExpectations.swift
+++ b/Sources/PublisherExpectations/PublisherExpectations.swift
@@ -11,31 +11,40 @@ import XCTest
 /// An expectation that is fulfilled when a publisher emits a value that matches a certain condition.
 public final class PublisherValueExpectation<P: Publisher>: XCTestExpectation {
     private var cancellable: AnyCancellable?
+    private var isConditionFulfilled: Bool = false
 
     /// Initializes a PublisherValueExpectation that is fulfilled when the publisher emits a value that matches the condition.
     public init(
         _ publisher: P,
         condition: @escaping (P.Output) -> Bool,
-        description expectationDescription: String? = nil)
+        description expectationDescription: String? = nil,
+        file: StaticString = #file, line: UInt = #line)
     {
         let description = expectationDescription ?? "Publisher expected to emit a value that matches the condition."
         super.init(description: description)
-        cancellable = publisher.sink { _ in
-        } receiveValue: { [weak self] value in
-            if condition(value) {
-                self?.fulfill()
+        cancellable = publisher.sink(receiveCompletion: { [weak self] completion in
+            guard let self else { return }
+            if !self.isConditionFulfilled {
+                self.checkImmediateFailure(file: file, line: line)
             }
-        }
+        }, receiveValue: { [weak self] value in
+            guard let self else { return }
+            if condition(value) {
+                self.fulfill()
+                self.isConditionFulfilled = true
+            }
+        })
     }
 
     /// Initializes a PublisherValueExpectation that is fulfilled when the publisher emits the expected value.
     public convenience init(
         _ publisher: P, expectedValue: P.Output,
-        description expectationDescription: String? = nil
+        description expectationDescription: String? = nil,
+        file: StaticString = #file, line: UInt = #line
     ) where P.Output: Equatable
     {
         let description = expectationDescription ?? "Publisher expected to emit the value '\(expectedValue)'"
-        self.init(publisher, condition: { $0 == expectedValue }, description: description)
+        self.init(publisher, condition: { $0 == expectedValue }, description: description, file: file, line: line)
     }
 }
 
@@ -47,7 +56,8 @@ public final class PublisherFinishedExpectation<P: Publisher>: XCTestExpectation
     /// Initializes a PublisherFinishedExpectation that is fulfilled when the publisher completes successfully.
     public init(
         _ publisher: P,
-        description expectationDescription: String = "Publisher expected to finish")
+        description expectationDescription: String = "Publisher expected to finish",
+        file: StaticString = #file, line: UInt = #line)
     {
         super.init(description: expectationDescription)
         cancellable = publisher.sink(receiveCompletion: { [weak self] completion in
@@ -55,7 +65,7 @@ public final class PublisherFinishedExpectation<P: Publisher>: XCTestExpectation
             case .finished:
                 self?.fulfill()
             case .failure(_):
-                break
+                self?.checkImmediateFailure(file: file, line: line)
             }
         }, receiveValue: { _ in })
     }
@@ -64,20 +74,22 @@ public final class PublisherFinishedExpectation<P: Publisher>: XCTestExpectation
     public init(
         _ publisher: P,
         condition: @escaping (P.Output) -> Bool,
-        description expectationDescription: String? = nil)
+        description expectationDescription: String? = nil,
+        file: StaticString = #file, line: UInt = #line)
     {
-        let description = expectationDescription ?? "Publisher expected to finish after matching the condition."
+        let description = expectationDescription ?? "Publisher expected to finish after emitting a value that matches the condition."
         super.init(description: description)
         cancellable = publisher.sink(receiveCompletion: { [weak self] completion in
+            guard let self else { return }
             switch completion {
             case .finished:
-                guard let self else { return }
                 if self.isConditionFulfilled {
                     self.fulfill()
+                } else {
+                    self.checkImmediateFailure(file: file, line: line)
                 }
-                break
             case .failure(_):
-                break
+                self.checkImmediateFailure(file: file, line: line)
             }
         }, receiveValue: { [weak self] value in
             guard let self, !self.isConditionFulfilled else { return }
@@ -88,11 +100,12 @@ public final class PublisherFinishedExpectation<P: Publisher>: XCTestExpectation
     /// Initializes a PublisherFinishedExpectation that is fulfilled when the publisher completes successfully after emitting a certain value.
     public convenience init(
         _ publisher: P, expectedValue: P.Output,
-        description expectationDescription: String? = nil
+        description expectationDescription: String? = nil,
+        file: StaticString = #file, line: UInt = #line
     ) where P.Output: Equatable
     {
         let description = expectationDescription ?? "Publisher expected to finish after emitting the value '\(expectedValue)'"
-        self.init(publisher, condition: { $0 == expectedValue }, description: description)
+        self.init(publisher, condition: { $0 == expectedValue }, description: description, file: file, line: line)
     }
 }
 
@@ -104,16 +117,20 @@ public final class PublisherFailureExpectation<P: Publisher>: XCTestExpectation 
     public init(
         _ publisher: P,
         condition: @escaping (P.Failure) -> Bool,
-        description expectationDescription: String = "Failure was expected with an error matching the condition.")
+        description expectationDescription: String = "Failure was expected with an error matching the condition.",
+        file: StaticString = #file, line: UInt = #line)
     {
         super.init(description: expectationDescription)
         cancellable = publisher.sink(receiveCompletion: { [weak self] completion in
+            guard let self else { return }
             switch completion {
             case .finished:
-                break
+                self.checkImmediateFailure(file: file, line: line)
             case .failure(let error):
                 if condition(error) {
-                    self?.fulfill()
+                    self.fulfill()
+                } else {
+                    self.checkImmediateFailure(file: file, line: line)
                 }
             }
         }, receiveValue: { _ in })
@@ -122,19 +139,33 @@ public final class PublisherFailureExpectation<P: Publisher>: XCTestExpectation 
     /// Initializes a PublisherFailureExpectation for a publisher with the given description
     public convenience init(
         _ publisher: P,
-        description expectationDescription: String = "Failure was expected")
+        description expectationDescription: String = "Failure was expected",
+        file: StaticString = #file, line: UInt = #line)
     {
-        self.init(publisher, condition: { _ in true }, description: expectationDescription)
+        self.init(publisher, condition: { _ in true }, description: expectationDescription, file: file, line: line)
     }
 
     /// Initializes a PublisherFailureExpectation that is fulfilled when the publisher fails with an expected error.
     public convenience init(
         _ publisher: P,
         expectedError: P.Failure,
-        description expectationDescription: String? = nil
+        description expectationDescription: String? = nil,
+        file: StaticString = #file, line: UInt = #line
     ) where P.Failure: Equatable
     {
         let description = expectationDescription ?? "Failure was expected with '\(expectedError)'"
-        self.init(publisher, condition: { $0 == expectedError }, description: description)
+        self.init(publisher, condition: { $0 == expectedError }, description: description, file: file, line: line)
+    }
+}
+
+private extension XCTestExpectation {
+    func checkImmediateFailure(file: StaticString = #file, line: UInt = #line) {
+        // Add small delay to allow effectively setting isInverted property from outside
+        DispatchQueue.main.async {
+            if !self.isInverted {
+                XCTFail(self.description, file: file, line: line)
+                self.fulfill()  // required to break the `wait()` in the test and skip the timeout
+            }
+        }
     }
 }

--- a/Tests/PublisherExpectationsTests/PublisherFailureExpectationTests.swift
+++ b/Tests/PublisherExpectationsTests/PublisherFailureExpectationTests.swift
@@ -10,14 +10,13 @@ import Combine
 @testable import PublisherExpectations
 
 class PublisherFailureExpectationTests: XCTestCase {
-    struct ParseError: Error, Equatable {
-        var code: Int
-    }
 
+    // MARK: - Expected success
+    
     func testExpectPublisherToCompleteWithFailure() {
         let publisher = ["1", "2", "3", "a", "5"].publisher
             .tryMap {
-                guard let int = Int($0) else { throw ParseError(code: 100) }
+                guard let int = Int($0) else { throw SimpleError(code: 100) }
                 return int
             }
         let expectation = PublisherFailureExpectation(publisher)
@@ -27,7 +26,7 @@ class PublisherFailureExpectationTests: XCTestCase {
     func testInvertedExpectation() {
         let publisher = ["1", "2", "3", "4", "5"].publisher
             .tryMap {
-                guard let int = Int($0) else { throw ParseError(code: 100) }
+                guard let int = Int($0) else { throw SimpleError(code: 100) }
                 return int
             }
         let expectation = PublisherFailureExpectation(publisher)
@@ -38,10 +37,10 @@ class PublisherFailureExpectationTests: XCTestCase {
     func testExpectPublisherToFailWithErrorMatchingCondition() {
         let publisher = ["1", "2", "3", "a", "5"].publisher
             .tryMap {
-                guard let int = Int($0) else { throw ParseError(code: 100) }
+                guard let int = Int($0) else { throw SimpleError(code: 100) }
                 return int
             }
-            .mapError { $0 as? ParseError ?? ParseError(code: 0) }
+            .mapError { $0 as? SimpleError ?? SimpleError(code: 0) }
         let expectation = PublisherFailureExpectation(publisher) { $0.code == 100 }
         wait(for: [expectation], timeout: 0.1)
     }
@@ -49,11 +48,39 @@ class PublisherFailureExpectationTests: XCTestCase {
     func testExpectPublisherToFailWithExpectedError() {
         let publisher = ["1", "2", "3", "a", "5"].publisher
             .tryMap {
-                guard let int = Int($0) else { throw ParseError(code: 100) }
+                guard let int = Int($0) else { throw SimpleError(code: 100) }
                 return int
             }
-            .mapError { $0 as? ParseError ?? ParseError(code: 0) }
+            .mapError { $0 as? SimpleError ?? SimpleError(code: 0) }
         let expectation = PublisherFailureExpectation(publisher, expectedError: .init(code: 100))
         wait(for: [expectation], timeout: 0.1)
+    }
+
+    // MARK: - Expected failures
+
+    func testImmediateFailureWhenPublisherFailsWithoutEmittingExpectedError() {
+        XCTExpectFailure("PublisherFailureExpectation should fail") {
+            let failingPublisher = Fail(outputType: Int.self, failure: SimpleError(code: 1300))
+            let expectation = PublisherFailureExpectation(failingPublisher, expectedError: .init(code: -100))
+            wait(for: [expectation], timeout: 5)
+        }
+    }
+
+    func testImmediateFailureWhenPublisherFailsWithoutErrorMatchingCondition() {
+        XCTExpectFailure("PublisherFailureExpectation should fail") {
+            let failingPublisher = Fail(outputType: Int.self, failure: SimpleError(code: 1300))
+            let expectation = PublisherFailureExpectation(failingPublisher) { $0.code < 0 }
+            wait(for: [expectation], timeout: 5)
+        }
+    }
+
+    func testImmediateFailureWhenPublisherFinishesWithoutFailing() {
+        XCTExpectFailure("PublisherFailureExpectation should fail") {
+            let nonFailingPublisher = Just(200)
+                .setFailureType(to: SimpleError.self)
+                .mapError { _ in SimpleError(code: 1300) }
+            let expectation = PublisherFailureExpectation(nonFailingPublisher, expectedError: SimpleError(code: 1300))
+            wait(for: [expectation], timeout: 5)
+        }
     }
 }

--- a/Tests/PublisherExpectationsTests/PublisherFinishedExpectationTests.swift
+++ b/Tests/PublisherExpectationsTests/PublisherFinishedExpectationTests.swift
@@ -13,8 +13,15 @@ class PublisherFinishedExpectationTests: XCTestCase {
     let publisher = [1, 2, 3, 4, 5].publisher
     @Published var value = 0
 
+    // MARK: - Expected success
+    
     func testExpectPublisherToJustFinish() {
         let expectation = PublisherFinishedExpectation(publisher)
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func testExpectPublisherToFinishWithoutEmittingAnyValue() {
+        let expectation = PublisherFinishedExpectation([].publisher)
         wait(for: [expectation], timeout: 0.1)
     }
 
@@ -39,5 +46,29 @@ class PublisherFinishedExpectationTests: XCTestCase {
     func testExpectPublisherToFinishAfterEmittingAllValues() {
         let expectation = PublisherFinishedExpectation(publisher.collect(), expectedValue: [1,2,3,4,5])
         wait(for: [expectation], timeout: 0.1)
+    }
+
+    // MARK: - Expected failures
+
+    func testImmediateFailureWhenPublisherFinishesWithoutEmittingExpectedValue() {
+        XCTExpectFailure("PublisherFinishedExpectation should fail") {
+            let expectation = PublisherFinishedExpectation(publisher, expectedValue: 100)
+            wait(for: [expectation], timeout: 5)
+        }
+    }
+
+    func testImmediateFailureWhenPublisherFinishesWithoutMatchingCondition() {
+        XCTExpectFailure("PublisherFinishedExpectation should fail") {
+            let expectation = PublisherFinishedExpectation(publisher) { $0 > 100 }
+            wait(for: [expectation], timeout: 5)
+        }
+    }
+
+    func testImmediateFailureWhenPublisherFails() {
+        XCTExpectFailure("PublisherFinishedExpectation should fail") {
+            let failingPublisher = Fail(outputType: Int.self, failure: SimpleError(code: 1300))
+            let expectation = PublisherFinishedExpectation(failingPublisher, expectedValue: 3)
+            wait(for: [expectation], timeout: 5)
+        }
     }
 }


### PR DESCRIPTION
* Optimized execution time of failing tests by skipping expectation timeout.
* Display a more descriptive error in case of failure.